### PR TITLE
non rspec-rails dependent strategy included and documented

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,31 @@ Or install it yourself as:
 
 ### RSpec ###
 
-Require `capybara/email/rspec` in your `spec_helper`
+```ruby
+# spec/spec_helper.rb
+require 'capybara/rspec'
+require 'capybara/dsl'
+
+RSpec.configure do |config|
+	config.include Capybara::DSL
+end
+
+```
+
+```ruby
+# spec/any_spec.rb or less preferrably spec/spec_helper.rb
+require 'capybara/email/rspec'
+
+it 'should find one email' do
+	send_an_email!
+	all_emails.size.should == 1
+end
+```
+
+
+### Rails & RSpec ###
+
+Require `capybara/email/rails` in your `spec_helper`
 
 Example:
 
@@ -55,7 +79,7 @@ feature 'Emailer' do
 end
 ```
 
-### Test::Unit ###
+### Rails & Test::Unit ###
 
 Include `Capybara::Email::DSL` in your test class
 

--- a/lib/capybara/email/rails.rb
+++ b/lib/capybara/email/rails.rb
@@ -1,0 +1,6 @@
+require 'capybara/email'
+
+RSpec.configure do |config|
+  config.include Capybara::Email::DSL, :type => :request
+  config.include Capybara::Email::DSL, :type => :acceptance
+end

--- a/lib/capybara/email/rspec.rb
+++ b/lib/capybara/email/rspec.rb
@@ -1,6 +1,5 @@
 require 'capybara/email'
 
 RSpec.configure do |config|
-  config.include Capybara::Email::DSL, :type => :request
-  config.include Capybara::Email::DSL, :type => :acceptance
+  config.include Capybara::Email::DSL
 end


### PR DESCRIPTION
Request specs are part of rspec-rails.

I split the strategies for including the DSL. The documentation is a little opinionated but I think it's more best practice than not.

Dan
