### PR TITLE
dont throw away the query and fragment parts of url

### DIFF
--- a/lib/capybara/email/driver.rb
+++ b/lib/capybara/email/driver.rb
@@ -11,7 +11,7 @@ class Capybara::Email::Driver < Capybara::Driver::Base
     when :rack_test
       url.to_s
     else
-      Capybara.current_session.driver.send(:url, url.path)
+      Capybara.current_session.driver.send(:url, url.request_uri)
     end
 
     Capybara.current_session.driver.visit url


### PR DESCRIPTION
The current code throws away the query and fragment parts of a url being followed from an email when not using rack_test.  This change stops that from happening
