### PR TITLE
Support multipart mail.

### DIFF
--- a/lib/capybara/email/driver.rb
+++ b/lib/capybara/email/driver.rb
@@ -72,7 +72,15 @@ class Capybara::Email::Driver < Capybara::Driver::Base
   #
   # @return String
   def raw
-    email.body.encoded
+    if email.mime_type == 'multipart/alternative'
+      if email.html_part
+        return email.html_part.body.encoded
+      elsif email.text_part
+        return email.text_part.body.encoded
+      end
+    end
+
+    return email.body.encoded
   end
 
   private

--- a/spec/email/driver_spec.rb
+++ b/spec/email/driver_spec.rb
@@ -40,6 +40,21 @@ feature 'Integration test' do
     all_emails.should be_empty
   end
 
+  # should read html_part
+  scenario 'multipart email' do
+    email = deliver(multipart_email)
+
+    open_email('test@example.com')
+    current_email.click_link 'example'
+    page.should have_content 'Hello world!'
+    current_email.should have_content 'This is only a html test'
+
+    all_emails.first.should eq email
+
+    clear_emails
+    all_emails.should be_empty
+  end
+
   scenario 'via ActionMailer' do
     email = deliver(plain_email)
 
@@ -101,4 +116,17 @@ def plain_email
 This is only a plain test.
 http://example.com
   PLAIN
+end
+
+def multipart_email
+  Mail::Message.new do
+    to 'test@example.com'
+    text_part do
+      body plain_email.body.encoded
+    end
+    html_part do
+      content_type 'text/html; charset=UTF-8'
+      body html_email.body.encoded
+    end
+  end
 end


### PR DESCRIPTION
Prefer HTML part, then text part. If both cannot be found, use the raw
content.
