### PR TITLE
Added find_xpath to make compatible with edge capybara 2.1

### DIFF
--- a/lib/capybara/email/driver.rb
+++ b/lib/capybara/email/driver.rb
@@ -57,6 +57,9 @@ class Capybara::Email::Driver < Capybara::Driver::Base
     dom.xpath(selector).map { |node| Capybara::Email::Node.new(self, node) }
   end
 
+  alias_method :find_xpath, :find
+
+
   # String version of email HTML source
   #
   # @return String


### PR DESCRIPTION
Currently click_link throws the following with edge capybara:

```
     Failure/Error: current_email.click_link "Unsubscribe"
     NotImplementedError:
       NotImplementedError
     # /Users/karl/.rvm/gems/ruby-1.9.3-p327-falcon@viewthespace/bundler/gems/capybara-d73c24d3e3fb/lib/capybara/driver/base.rb:11:in `find_xpath'
     # /Users/karl/.rvm/gems/ruby-1.9.3-p327-falcon@viewthespace/bundler/gems/capybara-d73c24d3e3fb/lib/capybara/node/finders.rb:154:in `block in resolve_query'
     # /Users/karl/.rvm/gems/ruby-1.9.3-p327-falcon@viewthespace/bundler/gems/capybara-d73c24d3e3fb/lib/capybara/node/base.rb:78:in `synchronize'
```
