### PR TITLE
Decode email body before attempting to parse it

### DIFF
--- a/lib/capybara/email/driver.rb
+++ b/lib/capybara/email/driver.rb
@@ -77,13 +77,13 @@ class Capybara::Email::Driver < Capybara::Driver::Base
   def raw
     if email.mime_type == 'multipart/alternative'
       if email.html_part
-        return email.html_part.body.encoded
+        return email.html_part.body.to_s
       elsif email.text_part
-        return email.text_part.body.encoded
+        return email.text_part.body.to_s
       end
     end
 
-    return email.body.encoded
+    return email.body.to_s
   end
 
   private


### PR DESCRIPTION
In [some cases](http://guides.rubyonrails.org/action_mailer_basics.html#auto-encoding-header-values), Rails apps will generate email using quoted-printable encoding.  When this happens, capybara-email won't decode the HTML body before attempting to parse it, which leads to strange behavior.

(For example, I saw it attempt to follow a link that began with `=3Dhttps://www...`, because there happened to be a line break before the https.)

This patch uses `Mail::Message#to_s` to automatically decode the body before attempting to do anything with it.
