### PR TITLE
Add support for multipart/related messages

### DIFF
--- a/lib/capybara/email/driver.rb
+++ b/lib/capybara/email/driver.rb
@@ -75,7 +75,7 @@ class Capybara::Email::Driver < Capybara::Driver::Base
   #
   # @return String
   def raw
-    if email.mime_type == 'multipart/alternative'
+    if email.mime_type =~ /\Amultipart\/(alternative|related)\Z/
       if email.html_part
         return email.html_part.body.to_s
       elsif email.text_part

--- a/spec/email/driver_spec.rb
+++ b/spec/email/driver_spec.rb
@@ -55,6 +55,21 @@ feature 'Integration test' do
     all_emails.should be_empty
   end
 
+  # should read html_part
+  scenario 'multipart/related email' do
+    email = deliver(multipart_related_email)
+
+    open_email('test@example.com')
+    current_email.click_link 'example'
+    page.should have_content 'Hello world!'
+    current_email.should have_content 'This is only a html test'
+
+    all_emails.first.should eq email
+
+    clear_emails
+    all_emails.should be_empty
+  end
+
   scenario 'via ActionMailer' do
     email = deliver(plain_email)
 
@@ -128,5 +143,19 @@ def multipart_email
       content_type 'text/html; charset=UTF-8'
       body html_email.body.encoded
     end
+  end
+end
+
+def multipart_related_email
+  Mail::Message.new do
+    to 'test@example.com'
+    text_part do
+      body plain_email.body.encoded
+    end
+    html_part do
+      content_type 'text/html; charset=UTF-8'
+      body html_email.body.encoded
+    end
+    content_type 'multipart/related; charset=UTF-8'
   end
 end


### PR DESCRIPTION
When inlining an attachment (typically an image for use in an HTML email), the MIME type multipart/related is used, as opposed to the multipart/alternative MIME type typically expected with both an HTML and text body.

See:
http://en.wikipedia.org/wiki/MIME#Related
http://tools.ietf.org/html/rfc2387

It seems there's no branch for 2-1-stable as the readme would imply, so this is against master.
