### PR TITLE
Minor fix to Test::Unit section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,10 +90,16 @@ end
 
 ### Test::Unit ###
 
+Require `capybara/email` at the top of `test/test_helper.rb`
+
+```ruby
+  require 'capybara/email'
+```
+
 Include `Capybara::Email::DSL` in your test class
 
 ```ruby
-class ActionController::IntegrationTest
+class ActionDispatch::IntegrationTest
   include Capybara::Email::DSL
 end
 ```


### PR DESCRIPTION
Adds note about adding `require 'capybara/email'` to test helper
Changes ActionController::IntegrationTest to ActionDispatch::IntegrationTest
