### PR TITLE
Fix issue where opening links with a custom port would not be respected.

### DIFF
--- a/lib/capybara/email/driver.rb
+++ b/lib/capybara/email/driver.rb
@@ -7,7 +7,10 @@ class Capybara::Email::Driver < Capybara::Driver::Base
 
   def follow(url)
     url = URI.parse(url)
-    Capybara.current_session.visit([url.path, url.query].compact.join('?'))
+    host = "#{url.scheme}://#{url.host}"
+    host << ":#{url.port}" unless url.port == url.default_port
+    host_with_path = File.join(host, url.path)
+    Capybara.current_session.visit([host_with_path, url.query].compact.join('?'))
   end
 
   def body

--- a/spec/email/driver_spec.rb
+++ b/spec/email/driver_spec.rb
@@ -26,6 +26,20 @@ feature 'Integration test' do
     all_emails.should be_empty
   end
 
+  scenario 'html email follows links' do
+    email = deliver(html_email)
+    open_email('test@example.com')
+
+    current_email.click_link 'example'
+    page.current_url.should eq('http://example.com/')
+
+    current_email.click_link 'another example'
+    page.current_url.should eq('http://example.com:1234/')
+
+    current_email.click_link 'yet another example'
+    page.current_url.should eq('http://example.com:1234/some/path?foo=bar')
+  end
+
   scenario 'plain text email' do
     email = deliver(plain_email)
 
@@ -135,6 +149,8 @@ def html_email
     <p>
       This is only a html test.
       <a href="http://example.com">example</a>
+      <a href="http://example.com:1234">another example</a>
+      <a href="http://example.com:1234/some/path?foo=bar">yet another example</a>
     </p>
   </body>
 </html>


### PR DESCRIPTION
Hi Brian, I bumped into this today while writing some integration tests Selenium. Opening an email and link against a custom host/port will not respect the fully qualified URL. I've added some specs to illustrate the desired behavior and wanted to get your thoughts. Thanks!
