### PR TITLE
Adds the #find_xpath alias to Capybara::Email::Node

### DIFF
--- a/lib/capybara/email/node.rb
+++ b/lib/capybara/email/node.rb
@@ -34,6 +34,7 @@ class Capybara::Email::Node < Capybara::Driver::Node
   def find(locator)
     native.xpath(locator).map { |node| self.class.new(driver, node) }
   end
+  alias :find_xpath :find
 
   protected
 

--- a/spec/email/driver_spec.rb
+++ b/spec/email/driver_spec.rb
@@ -99,6 +99,12 @@ feature 'Integration test' do
     all_emails.should be_empty
   end
 
+  scenario 'email content matchers' do
+    email = deliver(multipart_email)
+    open_email('test@example.com')
+    current_email.should have_link('another example', :href => 'http://example.com:1234')
+  end
+
   scenario 'via ActionMailer' do
     email = deliver(plain_email)
 


### PR DESCRIPTION
- Capybara 2.1 uses #find_xpath to implement #has_link?
  and other matchers. Since #find uses xpath exclusively,
  this adds an alias for #find as #find_xpath
