### PR TITLE
Travis: Remove JRuby, Rubinius, and 1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 rvm:
-  - 1.9.3
   - 2.0.0
-  - jruby-19mode
-  - rbx-19mode
+
+cache:
+  bundler


### PR DESCRIPTION
- Adds Bundler caching
