### PR TITLE
Loosens the capybara version dependency to allow for minor version upgra...

### DIFF
--- a/capybara-email.gemspec
+++ b/capybara-email.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.version       = Capybara::Email::VERSION
 
   gem.add_dependency 'mail'
-  gem.add_dependency 'capybara', '~> 2.2.0'
+  gem.add_dependency 'capybara', '~> 2.2'
   gem.add_development_dependency 'actionmailer', '> 3.0'
   gem.add_development_dependency 'bourne'
   gem.add_development_dependency 'rspec'


### PR DESCRIPTION
...des.

I am not sure if there is a specific, undocumented, reason for keeping the version of capybara locked to a specific minor version, but this change allows for users to upgrade their versions of capybara a bit more freely.
