### PR TITLE
Adds methods for retrieving headers from a message.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 2.3.0
+* Adds `Capybara::Node::Email#header` and `Capybara::Node::Email#headers` for retrieving optional headers set on an email. -
+  Michael Dupuis

--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ feature 'Emailer' do
     current_email.should have_content 'Hello Joe!'
   end
 
+  scenario 'testing for a custom header' do
+    current_email.headers.should include 'header-key'
+  end
+
+  scenario 'testing for a custom header value' do
+    current_email.header('header-key').should eq 'header_value'
+  end
+
   scenario 'view the email body in your browser' do
     # the `launchy` gem is required
     current_email.save_and_open
@@ -125,6 +133,14 @@ class EmailTriggerControllerTest < ActionController::IntegrationTest
 
   test 'testing for content' do
     current_email.should have_content 'Hello Joe!'
+  end
+
+  test 'testing for a custom header' do
+    current_email.headers.should include 'header-key'
+  end
+
+  test 'testing for a custom header value' do
+    current_email.header('header-key').should eq 'header_value'
   end
 
   test 'view the email body in your browser' do

--- a/lib/capybara/node/email.rb
+++ b/lib/capybara/node/email.rb
@@ -35,6 +35,20 @@ class Capybara::Node::Email < Capybara::Node::Document
     base.from
   end
 
+  # Returns the value of the passed in header key.
+  #
+  # @return String
+  def header(key)
+    base.email.header[key].value
+  end
+
+  # Returns the header keys as an array of strings.
+  #
+  # @return [String]
+  def headers
+    base.email.header.fields.map(&:name)
+  end
+
   # Save a snapshot of the page.
   #
   # @param  [String] path     The path to where it should be saved [optional]

--- a/spec/node/email_spec.rb
+++ b/spec/node/email_spec.rb
@@ -67,4 +67,26 @@ describe Capybara::Node::Email do
       email.from.should include 'test@example.com'
     end
   end
+
+  describe '#header' do
+    before do
+      message['header-key'] = 'header_value'
+    end
+
+    it 'delegates to the base' do
+      email.header('header-key').should eq 'header_value'
+    end
+  end
+
+  describe '#headers' do
+    before do
+      message['first-key'] = 'first_value'
+      message['second-key'] = 'second_value'
+    end
+
+    it 'delegates to the base' do
+      email.headers.should include 'first-key'
+      email.headers.should include 'second-key'
+    end
+  end
 end


### PR DESCRIPTION
These methods allow us to retrieve optional headers added to emails.

From what I can tell, we can't delegate retrieval of the headers to [Mail::Message#header](https://github.com/mikel/mail/blob/master/lib/mail/message.rb#L411) and easily access an optional header which has been passed in. All headers are returned or the header value is set via the parameter passed in.

This introduces a discrepancy between how `#header` functions when called on an email in capybara-email and how it functions in `Mail::Message#header`. I'm open to renaming these methods `optional_header` and `optional_headers` to denote that we're retrieving those from the email and to maintain consistency with how the api is currently implemented (delegating to `Mail::Message` when possible).
