### PR TITLE
Remove version requirement on `capybara`.

### DIFF
--- a/capybara-email.gemspec
+++ b/capybara-email.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.version       = Capybara::Email::VERSION
 
   gem.add_dependency 'mail'
-  gem.add_dependency 'capybara', '~> 2.3'
+  gem.add_dependency 'capybara'
   gem.add_development_dependency 'actionmailer', '> 3.0'
   gem.add_development_dependency 'bourne'
   gem.add_development_dependency 'rspec'


### PR DESCRIPTION
There are some rspec3 deprecation warnings in capybara 2.2.x. The latest capybara is 2.4.1 which has these addressed in it. Can we just remove the requirement on version?
