### PR TITLE
Added find_css to email driver

### DIFF
--- a/lib/capybara/email/driver.rb
+++ b/lib/capybara/email/driver.rb
@@ -35,6 +35,9 @@ class Capybara::Email::Driver < Capybara::Driver::Base
 
   alias_method :find_xpath, :find
 
+  def find_css(selector)
+    dom.css(selector).map { |node| Capybara::Email::Node.new(self, node) }
+  end
 
   # String version of email HTML source
   #

--- a/spec/email/driver_spec.rb
+++ b/spec/email/driver_spec.rb
@@ -19,6 +19,7 @@ feature 'Integration test' do
     current_email.click_link 'example'
     expect(page).to have_content 'Hello world!'
     expect(current_email).to have_content 'This is only a html test'
+    expect(current_email).to have_css 'a'
 
     expect(all_emails.first).to eq email
 


### PR DESCRIPTION
Upgrading a project that was on Capybara 2.0 and capybara-email 2.0.2 to Capybara 2.4.4 and capybara-email 2.4.0, and I'm getting:

``` ruby
NotImplementedError: NotImplementedError
from /Users/woody/Src/in_play/vendor/ruby/2.1.0/gems/capybara-2.4.4/lib/capybara/driver/base.rb:15:in `find_css'
```

I found a random commit in the fork tree that fixes this from over a year ago, and my best guess is some capybara default changed from using find_xpath to find_css?

Anyways, seems like a valuable addition, and fixes my bug.
