### PR TITLE
Change parent class in Test::Unit example

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ end
 Example:
 
 ```ruby
-class EmailTriggerControllerTest < ActionController::IntegrationTest
+class EmailTriggerControllerTest < ActionDispatch::IntegrationTest
   def setup
     # will clear the message queue
     clear_emails


### PR DESCRIPTION
The Test::Unit example subclassed ActionController::IntegrationTest when it should be ActionDispatch::IntegrationTest

Another instance of this typo was fixed previously in 7ad5a24