### PR TITLE
Include in System specs for RSpec 3.7

### DIFF
--- a/lib/capybara/email/rspec.rb
+++ b/lib/capybara/email/rspec.rb
@@ -1,7 +1,8 @@
 require 'capybara/email'
 
 RSpec.configure do |config|
+  config.include Capybara::Email::DSL, :type => :acceptance
   config.include Capybara::Email::DSL, :type => :feature
   config.include Capybara::Email::DSL, :type => :request
-  config.include Capybara::Email::DSL, :type => :acceptance
+  config.include Capybara::Email::DSL, :type => :system
 end


### PR DESCRIPTION
RSpec 3.7 includes "System" tests that are intended to replace Features. This PR ensures that capybara-email is loaded in these tests.

More info about RSpec System Tests: https://medium.com/table-xi/a-quick-guide-to-rails-system-tests-in-rspec-b6e9e8a8b5f6
