### PR TITLE
Allow Capybara v3.0 in gemspec

### DIFF
--- a/capybara-email.gemspec
+++ b/capybara-email.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.version       = Capybara::Email::VERSION
 
   gem.add_dependency 'mail'
-  gem.add_dependency 'capybara', '~> 2.4'
+  gem.add_dependency 'capybara', '> 2.4'
   gem.add_development_dependency 'actionmailer', '> 3.0'
   gem.add_development_dependency 'bourne'
   gem.add_development_dependency 'rspec'


### PR DESCRIPTION
Allows compatibility with [Capybara v3.0.0](https://github.com/teamcapybara/capybara/releases/tag/3.0.0), which should be [compatible](https://github.com/teamcapybara/capybara/blob/master/UPGRADING.md).