### PR TITLE
Fix compatibility of #click_on with Capybara v3.17 due to changes in checking if disabled

### DIFF
--- a/lib/capybara/email/node.rb
+++ b/lib/capybara/email/node.rb
@@ -31,6 +31,10 @@ class Capybara::Email::Node < Capybara::Driver::Node
     string_node.visible?
   end
 
+  def disabled?
+    string_node.disabled?
+  end
+
   def find(locator)
     native.xpath(locator).map { |node| self.class.new(driver, node) }
   end

--- a/spec/email/driver_spec.rb
+++ b/spec/email/driver_spec.rb
@@ -41,6 +41,14 @@ feature 'Integration test' do
     expect(page.current_url).to eq('http://example.com:1234/some/path?foo=bar')
   end
 
+  scenario 'html email follows links via click_on' do
+    email = deliver(html_email)
+    open_email('test@example.com')
+
+    current_email.click_on 'example'
+    expect(page.current_url).to eq('http://example.com/')
+  end
+
   scenario 'plain text email' do
     email = deliver(plain_email)
 


### PR DESCRIPTION
Looks like https://github.com/teamcapybara/capybara/commit/f94033a48ef80e0c4e95a4fab4f5b452302b22f4 changed how it finds non-disabled `link_or_button` by no longer blindly allowing `a` tags.

Without this patch, I was getting a `NotImplementedError` from the line where I call `current_email.click_on`.

The tests seem to pass with both Capybara v3.16 and v3.17 after this patch, so it shouldn't cause any backwards compatibility issues.