### PR TITLE
README: Use SVG badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # CapybaraEmail #
 
 [![Build Status](https://travis-ci.org/DavyJonesLocker/capybara-email.svg?branch=master)](https://travis-ci.org/DavyJonesLocker/capybara-email)
-[![Dependency Status](https://gemnasium.com/badges/DavyJonesLocker/capybara-email.svg?travis)](https://gemnasium.com/DavyJonesLocker/capybara-email.svg)
-[![Code Climate](https://d3s6mut3hikguw.cloudfront.net/github/dockyard/capybara-email.png)](https://codeclimate.com/github/dockyard/capybara-email)
+[![Code Climate](https://d3s6mut3hikguw.cloudfront.net/github/dockyard/capybara-email.svg)](https://codeclimate.com/github/dockyard/capybara-email)
 
 Easily test [ActionMailer](https://github.com/rails/rails/tree/master/actionmailer) and [Mail](https://github.com/mikel/mail) messages in your Capybara integration tests
 


### PR DESCRIPTION

- This PR changes the build badges to SVG for sharper readability  ✨
- Also: Drops a badge no longer in service
