### PR TITLE
warning: literal string frozen in ruby 2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['2.7', '3.0', '3.1', '3.2', '3.3', '3.4']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+
+      - name: Run tests
+        run: bundle exec rake
+        continue-on-error: ${{ matrix.continue-on-error || false }}

--- a/lib/capybara-email.rb
+++ b/lib/capybara-email.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'capybara'
 require 'mail'
 

--- a/lib/capybara/email.rb
+++ b/lib/capybara/email.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Capybara
   module Node
     autoload :Email,    'capybara/node/email'

--- a/lib/capybara/email/driver.rb
+++ b/lib/capybara/email/driver.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Capybara::Email::Driver < Capybara::Driver::Base
   attr_reader :email
 

--- a/lib/capybara/email/driver.rb
+++ b/lib/capybara/email/driver.rb
@@ -8,7 +8,7 @@ class Capybara::Email::Driver < Capybara::Driver::Base
   def follow(url)
     url = URI.parse(url)
     host = "#{url.scheme}://#{url.host}"
-    host << ":#{url.port}" unless url.port == url.default_port
+    host += ":#{url.port}" unless url.port == url.default_port
     host_with_path = File.join(host, url.path)
     Capybara.current_session.visit([host_with_path, url.query].compact.join('?'))
   end

--- a/lib/capybara/email/dsl.rb
+++ b/lib/capybara/email/dsl.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Capybara::Email::DSL
 
   # Returns the currently set email.

--- a/lib/capybara/email/node.rb
+++ b/lib/capybara/email/node.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Capybara::Email::Node < Capybara::Driver::Node
   def text
     native.text

--- a/lib/capybara/email/rspec.rb
+++ b/lib/capybara/email/rspec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'capybara/email'
 
 RSpec.configure do |config|

--- a/lib/capybara/email/version.rb
+++ b/lib/capybara/email/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Capybara
   module Email
     VERSION = '3.0.2'

--- a/lib/capybara/node/email.rb
+++ b/lib/capybara/node/email.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Capybara::Node::Email < Capybara::Node::Document
 
   # Delegate to the email body

--- a/spec/email/driver_spec.rb
+++ b/spec/email/driver_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 class TestApp

--- a/spec/node/email_spec.rb
+++ b/spec/node/email_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Capybara::Node::Email do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rubygems'
 require 'bundler/setup'
 


### PR DESCRIPTION
We faced an issue when tried to run our tests in ruby 2.7.4 with env `RUBYOPT=--enable-frozen-string-literal`
```bash
       can't modify frozen String: "http://localhost/"
     [Screenshot Image]: /builds/
     # /usr/local/rvm/gems/ruby-2.7.4/gems/capybara-email-3.0.2/lib/capybara/email/driver.rb:11:in `follow'
```