### PR TITLE
Implement `#respond_to_missing?`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
 
   * Avoid modifying frozen strings ([yuri-zubov][yuri-zubov])
+  * Define `#respond_to_missing?` on `Capybara::Node::Email`
+    ([tylerhunt][tylerhunt])
 
 ## 3.0.0
 
@@ -17,4 +19,5 @@
   * Corrects `inspect` of `Capybara::Node::Email`
   * Delegate all missing methods in `Capybara::Node::Email` to `base.email`
 
+[tylerhunt]: https://github.com/tylerhunt
 [yuri-zubov]: https://github.com/yuri-zubov

--- a/lib/capybara/email/driver.rb
+++ b/lib/capybara/email/driver.rb
@@ -68,16 +68,20 @@ class Capybara::Email::Driver < Capybara::Driver::Base
 
   private
 
-  def method_missing(meth, *args, &block)
-    if email.respond_to?(meth)
+  def method_missing(method_name, *args, &block)
+    if email.respond_to?(method_name)
       if args.empty?
-        email.send(meth)
+        email.send(method_name)
       else
-        email.send(meth, args)
+        email.send(method_name, args)
       end
     else
       super
     end
+  end
+
+  def respond_to_missing?(method_name, include_private = false)
+    email.respond_to?(method_name, include_private || super)
   end
 
   def convert_to_html(text)

--- a/lib/capybara/node/email.rb
+++ b/lib/capybara/node/email.rb
@@ -62,14 +62,16 @@ class Capybara::Node::Email < Capybara::Node::Document
 
   private
 
-  # Tries to send to `base` first.
-  # If an NotImplementedError is hit because some finders/matchers/etc. aren't implemented,
-  # fall back to treating the message body as a Capybara::Node::Simple
-  def method_missing(meth, *args, &block)
-    begin
-      base.send(meth, *args)
-    rescue NotImplementedError
-      body_as_simple_node.send(meth, *args)
-    end
+  # Tries to send to `base` first. If an NotImplementedError is hit because
+  # some finders/matchers/etc. aren't implemented, fall back to treating the
+  # message body as a Capybara::Node::Simple
+  def method_missing(method_name, *args, &block)
+    base.send(method_name, *args)
+  rescue NotImplementedError
+    body_as_simple_node.send(method_name, *args)
+  end
+
+  def respond_to_missing?(method_name, include_private = false)
+    base.respond_to?(method_name, include_private) || super
   end
 end

--- a/spec/node/email_spec.rb
+++ b/spec/node/email_spec.rb
@@ -37,6 +37,10 @@ describe Capybara::Node::Email do
     it 'delegates to the base' do
       expect(email.subject).to eq 'Test subject'
     end
+
+    it 'responds to :subject' do
+      expect(email).to respond_to(:subject)
+    end
   end
 
   describe '#to' do
@@ -46,6 +50,10 @@ describe Capybara::Node::Email do
 
     it 'delegates to the base' do
       expect(email.to).to include 'test@example.com'
+    end
+
+    it 'responds to :to' do
+      expect(email).to respond_to(:to)
     end
   end
 
@@ -57,6 +65,10 @@ describe Capybara::Node::Email do
     it 'delegates to the base' do
       expect(email.reply_to).to include 'test@example.com'
     end
+
+    it 'responds to :reply_to' do
+      expect(email).to respond_to(:reply_to)
+    end
   end
 
   describe '#from' do
@@ -66,6 +78,10 @@ describe Capybara::Node::Email do
 
     it 'delegates to the base' do
       expect(email.from).to include 'test@example.com'
+    end
+
+    it 'responds to :from' do
+      expect(email).to respond_to(:from)
     end
   end
 


### PR DESCRIPTION
Define `#respond_to_missing?` on `Capybara::Email::Driver` and `Capybara::Node::Email`.

The case for this has been laid out in a [lovely, vintage piece by Thoughtbot](https://thoughtbot.com/blog/always-define-respond-to-missing-when-overriding), but, in practical terms, fixes the following usage with RSpec which currently doesn't work:

```ruby
expect(current_email).to have_attributes(subject: /Hi!/)
```